### PR TITLE
useEters

### DIFF
--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -44,4 +44,25 @@ Resumen conciso de los elementos faltantes, riesgos y mejoras sugeridas para el 
 - `README.md` — añadir ejemplos de payloads, flujo (issue → verify → QR) y limitaciones.
 - `package.json` — añadir scripts `build`, `start:prod`, y dependencias de test/lint.
 
+**Testnets y pruebas de anclaje (Ethereum)**
+
+- **Qué es / por qué:** Usar una testnet permite probar el anclaje en una cadena real sin gastar ETH real. Ideal para validar que la transacción que contiene el hash se publica correctamente.
+- **Redes recomendadas:** Sepolia o Goerli (Sepolia suele ser la más estable recientemente).
+- **Cómo probar (rápido):** consigue un RPC (Infura/Alchemy/otro) y test-ETH desde un faucet, luego exporta las variables de entorno y arranca la app:
+
+```bash
+export ETH_RPC=https://sepolia.infura.io/v3/<PROJECT_ID>
+export ETH_PRIVATE_KEY=0x...   # cuenta de prueba con test-ETH
+yarn
+yarn start
+```
+
+- Emite un credential desde la UI (`/public`) o con `POST /issue`; el PoC intentará enviar una tx que incluirá el hash en `data` y guardará el `ethTx` en `data/anchors.json`.
+- **Precauciones:**
+	- Usa sólo claves de prueba en testnets; no pongas claves reales en `ETH_PRIVATE_KEY` ni en repositorios.
+	- Las transacciones en testnet siguen gastando gas (test-ETH). Usa un faucet oficial para obtener fondos.
+	- Si quieres evitar gestionar claves, considera usar una cuenta temporal o un servicio de relayer en pruebas.
+
+Agregar pruebas automáticas que mockeen `anchorToEthereum` puede ayudar a no depender de la testnet para CI.
+
 Si quieres, puedo implementar la primera prioridad ahora: añadir `ajv` para validación y crear tests unitarios para la firma/verificación. ¿Procedo con eso?

--- a/README.md
+++ b/README.md
@@ -30,3 +30,17 @@ yarn start
 ```
 
 Open `http://localhost:3000/public` to use the verification UI.
+
+Ethereum anchoring (PoC)
+
+- This PoC can optionally anchor credential hashes on Ethereum by sending
+	a zero-value transaction with the hash in the `data` field.
+- Set environment variables before running the server:
+
+```bash
+export ETH_RPC=https://your-rpc.example
+export ETH_PRIVATE_KEY=0xYOUR_PRIVATE_KEY
+yarn start
+```
+
+If the vars are not set, the app will keep working and only store local anchors in `data/anchors.json`.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "express": "^4.18.2",
     "nanoid": "^4.0.0",
     "qrcode": "^1.5.1",
-    "tweetnacl": "^1.0.3"
+    "tweetnacl": "^1.0.3",
+    "ethers": "^6.11.0"
   },
   "devDependencies": {
     "ts-node": "^10.9.1",

--- a/src/issuer.ts
+++ b/src/issuer.ts
@@ -2,6 +2,7 @@ import { nanoid } from 'nanoid'
 import fs from 'fs/promises'
 import path from 'path'
 import { sha256, signMessage, loadKey } from './utils/crypto'
+import { anchorToEthereum } from './utils/eth'
 
 type Subject = { id?: string; [k: string]: any }
 
@@ -46,9 +47,20 @@ export async function issueCredential(subject: Subject, issuerName = 'Demo Issue
   const anchorsPath = path.join('data', 'anchors.json')
   let anchors: Array<any> = []
   try { anchors = JSON.parse(await fs.readFile(anchorsPath, 'utf8')) } catch (e) { anchors = [] }
-  anchors.push({ id, hash, timestamp: new Date().toISOString() })
+  const anchorEntry: any = { id, hash, timestamp: new Date().toISOString() }
+
+  // try anchoring to Ethereum (simple PoC). Requires ETH_RPC and ETH_PRIVATE_KEY env vars.
+  try {
+    const txHash = await anchorToEthereum(hash)
+    anchorEntry.ethTx = txHash
+  } catch (e: any) {
+    // fail silently for PoC — keep local anchoring
+    console.warn('Ethereum anchoring skipped:', e.message)
+  }
+
+  anchors.push(anchorEntry)
   await fs.mkdir('data', { recursive: true })
   await fs.writeFile(anchorsPath, JSON.stringify(anchors, null, 2), 'utf8')
 
-  return { id, certPath, hash }
+  return { id, certPath, hash, anchor: anchorEntry }
 }

--- a/src/utils/eth.ts
+++ b/src/utils/eth.ts
@@ -1,0 +1,24 @@
+import { ethers } from 'ethers'
+
+// Anchor a hex hash (without 0x) on Ethereum by sending a zero-value tx
+// with the hash in the data field. Uses env vars: ETH_RPC, ETH_PRIVATE_KEY.
+export async function anchorToEthereum(hashHex: string) {
+  const rpc = process.env.ETH_RPC
+  const pk = process.env.ETH_PRIVATE_KEY
+  if (!rpc || !pk) throw new Error('ETH_RPC or ETH_PRIVATE_KEY not configured')
+
+  const provider = new ethers.providers.JsonRpcProvider(rpc)
+  const wallet = new ethers.Wallet(pk, provider)
+
+  const tx = await wallet.sendTransaction({
+    to: wallet.address,
+    value: 0,
+    data: '0x' + hashHex
+  })
+
+  // wait for 1 confirmation
+  await tx.wait(1)
+  return tx.hash
+}
+
+export default anchorToEthereum

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@adraffy/ens-normalize@1.10.1":
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz#63430d04bd8c5e74f8d7d049338f1cd9d4f02069"
+  integrity sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==
+
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
@@ -26,6 +31,18 @@
   dependencies:
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
+
+"@noble/curves@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.2.0.tgz#92d7e12e4e49b23105a2555c6984d41733d65c35"
+  integrity sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==
+  dependencies:
+    "@noble/hashes" "1.3.2"
+
+"@noble/hashes@1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.2.tgz#6f26dbc8fbc7205873ce3cee2f690eba0d421b39"
+  integrity sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==
 
 "@tsconfig/node10@^1.0.7":
   version "1.0.12"
@@ -98,6 +115,13 @@
   integrity sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==
   dependencies:
     undici-types "~7.18.0"
+
+"@types/node@22.7.5":
+  version "22.7.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.7.5.tgz#cfde981727a7ab3611a481510b473ae54442b92b"
+  integrity sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==
+  dependencies:
+    undici-types "~6.19.2"
 
 "@types/node@^20.2.5":
   version "20.19.37"
@@ -176,6 +200,11 @@ acorn@^8.11.0, acorn@^8.4.1:
   version "8.16.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.16.0.tgz#4ce79c89be40afe7afe8f3adb902a1f1ce9ac08a"
   integrity sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==
+
+aes-js@4.0.0-beta.5:
+  version "4.0.0-beta.5"
+  resolved "https://registry.yarnpkg.com/aes-js/-/aes-js-4.0.0-beta.5.tgz#8d2452c52adedebc3a3e28465d858c11ca315873"
+  integrity sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==
 
 ansi-regex@^5.0.1:
   version "5.0.1"
@@ -438,6 +467,19 @@ etag@~1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==
+
+ethers@^6.11.0:
+  version "6.16.0"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-6.16.0.tgz#fff9b4f05d7a359c774ad6e91085a800f7fccf65"
+  integrity sha512-U1wulmetNymijEhpSEQ7Ct/P/Jw9/e7R1j5XIbPRydgV2DjLVMsULDlNksq3RQnFgKoLlZf88ijYtWEXcPa07A==
+  dependencies:
+    "@adraffy/ens-normalize" "1.10.1"
+    "@noble/curves" "1.2.0"
+    "@noble/hashes" "1.3.2"
+    "@types/node" "22.7.5"
+    aes-js "4.0.0-beta.5"
+    tslib "2.7.0"
+    ws "8.17.1"
 
 express@^4.18.2:
   version "4.22.1"
@@ -1102,6 +1144,11 @@ tsconfig@^7.0.0:
     strip-bom "^3.0.0"
     strip-json-comments "^2.0.0"
 
+tslib@2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.7.0.tgz#d9b40c5c40ab59e8738f297df3087bf1a2690c01"
+  integrity sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==
+
 tweetnacl@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-1.0.3.tgz#ac0af71680458d8a6378d0d0d050ab1407d35596"
@@ -1119,6 +1166,11 @@ typescript@^5.1.3:
   version "5.9.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
   integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
+
+undici-types@~6.19.2:
+  version "6.19.8"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.19.8.tgz#35111c9d1437ab83a7cdc0abae2f26d88eda0a02"
+  integrity sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==
 
 undici-types@~6.21.0:
   version "6.21.0"
@@ -1168,6 +1220,11 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
+
+ws@8.17.1:
+  version "8.17.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.17.1.tgz#9293da530bb548febc95371d90f9c878727d919b"
+  integrity sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==
 
 xtend@^4.0.0:
   version "4.0.2"


### PR DESCRIPTION
# Diferencias: rama `useEters` vs `main`

Resumen breve
- `useEters` mantiene el PoC Blockcerts original pero añade soporte opcional de anclaje en Ethereum (PoC). Si no se configuran las variables de entorno, se conserva el anclaje local en `data/anchors.json`.

Archivos cambiados
- `src/utils/eth.ts` — NUEVO: función `anchorToEthereum` que envía una tx con el hash en `data` (usa `ethers`).
- `src/issuer.ts` — MOD: importa y usa `anchorToEthereum` en un intento de anclar el hash en Ethereum; captura fallos y cae back a anclaje local.
- `README.md` — MOD: documentación de uso opcional de anclaje en Ethereum y variables de entorno (`ETH_RPC`, `ETH_PRIVATE_KEY`).
- `IMPROVEMENTS.md` — MOD: notas sobre añadir anclaje en testnet (recomendación/pruebas).
- `package.json` — MOD: añade `ethers` dependency (ya estaba presente en esta branch).
- `yarn.lock` — MOD: (lockfile actualizado).

Cambios clave (fragmentos)

- Import en `src/issuer.ts`:

```ts
import { anchorToEthereum } from './utils/eth'
```

- Intento de anclaje en `src/issuer.ts` (nuevo comportamiento dentro del flujo de emisión):

```ts
// try anchoring to Ethereum (simple PoC). Requires ETH_RPC and ETH_PRIVATE_KEY env vars.
try {
  const txHash = await anchorToEthereum(hash)
  anchorEntry.ethTx = txHash
} catch (e: any) {
  // fail silently for PoC — keep local anchoring
  console.warn('Ethereum anchoring skipped:', e.message)
}
```

- Nuevo archivo `src/utils/eth.ts` (resumen):

```ts
import { ethers } from 'ethers'

// Anchor a hex hash (without 0x) on Ethereum by sending a zero-value tx
// with the hash in the data field. Uses env vars: ETH_RPC, ETH_PRIVATE_KEY.
export async function anchorToEthereum(hashHex: string) {
  const rpc = process.env.ETH_RPC
  const pk = process.env.ETH_PRIVATE_KEY
  if (!rpc || !pk) throw new Error('ETH_RPC or ETH_PRIVATE_KEY not configured')

  const provider = new ethers.providers.JsonRpcProvider(rpc)
  const wallet = new ethers.Wallet(pk, provider)

  const tx = await wallet.sendTransaction({
    to: wallet.address,
    value: 0,
    data: '0x' + hashHex
  })

  // wait for 1 confirmation
  await tx.wait(1)
  return tx.hash
}

export default anchorToEthereum
```

Cómo probar el anclaje Ethereum
- Variables necesarias (ejemplo):

```bash
export ETH_RPC=https://sepolia.infura.io/v3/<PROJECT_ID>
export ETH_PRIVATE_KEY=0xYOUR_TEST_PRIVATE_KEY
yarn
yarn start
```

- Flujo: emitir un credential (UI `/public` o `POST /issue`) → `issuer` intentará enviar tx → `data/anchors.json` guardará `ethTx` con el hash si la tx fue enviada.
- Precauciones: usar sólo claves de prueba y test-ETH; la PoC captura errores y continúa con el anclaje local si no se puede conectar.

Notas:
- Cambios pequeños y focalizados: añade una dependencia (`ethers`) y la función de anclaje. Se mantiene retrocompatibilidad (fallthrough a anclaje local).
- Recomendación: en el PR añadir un ejemplo de `.env.sample`, documentar el coste/riesgos, y añadir tests que mockeen `anchorToEthereum` para CI.

Pendientes:
- generar un `.env.sample` y actualizar `README.md` con pasos concretos para probar en Sepolia/Goerli;
- añadir tests unitarios que mockeen `ethers` y validen que, si `anchorToEthereum` falla, el anclaje local sigue funcionando.
