### PR TITLE
blockcerts

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,9 @@
+## Example environment variables for Ethereum anchoring (do not commit secrets)
+# RPC endpoint for chosen network (Infura/Alchemy or own node)
+ETH_RPC=https://sepolia.infura.io/v3/<PROJECT_ID>
+
+# Private key used to send transactions (test account only)
+ETH_PRIVATE_KEY=0xYOUR_TEST_PRIVATE_KEY
+
+# Optional: deployed Anchor contract address (used by scripts/anchor_batch.ts)
+CONTRACT_ADDRESS=0xYOUR_CONTRACT_ADDRESS

--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -8,6 +8,7 @@ Resumen conciso de los elementos faltantes, riesgos y mejoras sugeridas para el 
 - **Persistencia segura:** `data/anchors.json` se lee/escribe sin control de concurrencia; **riesgo:** corrupción por race conditions. Soluciones: migrar a SQLite o añadir un append-only log con locking.
 - **Validación de inputs:** Falta validación estructural de payloads para `POST /issue` y `POST /verify`. Añadir validación con `ajv` o similar (esquemas JSON/VC mínimos) para evitar inputs malformados.
 - **Determinismo del hash:** Actualmente el hash se calcula usando `JSON.stringify` (orden de propiedades no garantizado). Usar canonical JSON o ordenar keys para evitar falsos negativos en verificación.
+	- Estado: se añadió `jsonld` canonicalization (URDNA2015) y el código canonicaliza antes de hashear.
 - **Manejo de claves:** Claves guardadas en `keys/` en texto plano (aceptable para PoC, peligroso en producción). Documentar y evitar commit; recomendar secret manager/HSM en prod.
 
 **Alta prioridad (mejoran fiabilidad y pruebas)**
@@ -23,6 +24,7 @@ Resumen conciso de los elementos faltantes, riesgos y mejoras sugeridas para el 
 
 **Baja prioridad (mejoras para interoperabilidad y features)**
 - **JSON-LD / W3C VC compatibilidad:** Usar `jsonld` y considerar Linked Data Signatures / LD-CANON para compatibilidad con wallets/verificadores externos.
+	- Estado: se integró `jsonld.canonize` y se generó un archivo `keys/issuer-ld.json` con `publicKeyBase58`. Falta integrar `jsonld-signatures` / `ed25519-signature-2018` para pruebas LD completas.
 - **Generación de QR en UI y endpoint:** Ya se añadió `/cert/:id/qrcode` y botón en `public/index.html`; documentar uso en README.
 - **UI/UX para emisión:** Añadir UI para emitir certificados desde el navegador (form simple que hace `POST /issue`).
 - **Integración con wallets:** Exportar credenciales en formatos aceptados por wallets (VC JSON) y probar import.
@@ -32,9 +34,10 @@ Resumen conciso de los elementos faltantes, riesgos y mejoras sugeridas para el 
 - **Backup y migraciones:** Si se migra a DB, añadir scripts de migración y backup para `anchors` y `certs`.
 
 **Sugerencia de prioridades para los próximos pasos (mínimo viable)**
-1. Añadir validación (`ajv`) y tests unitarios para crypto (1-2 días).
-2. Corregir persistencia (migrar a SQLite) y actualizar lectura/escritura (0.5-1 día).
-3. Evitar regeneración de claves en `seed` y documentar workflow de claves (0.25 día).
+1. Integrar `jsonld-signatures` + `ed25519-signature-2018` para proofs LD completos (1-2 días).
+2. Añadir validación (`ajv`) y tests unitarios para crypto y endpoints (1-2 días).
+3. Corregir persistencia (migrar a SQLite or add append-only log) y actualizar lectura/escritura (0.5-1 día).
+4. Evitar regeneración de claves en `seed` y documentar workflow de claves (0.25 día).
 
 **Archivos a modificar (referencia)**
 - `src/server.ts` — añadir validación, CORS, rate-limiting y respuesta estandarizada.
@@ -43,6 +46,14 @@ Resumen conciso de los elementos faltantes, riesgos y mejoras sugeridas para el 
 - `scripts/seed_example.ts` — no regenerar claves si existen.
 - `README.md` — añadir ejemplos de payloads, flujo (issue → verify → QR) y limitaciones.
 - `package.json` — añadir scripts `build`, `start:prod`, y dependencias de test/lint.
+
+**Cambios realizados en este PoC**
+- `src/utils/merkle.ts`: Merkle root, proof generation and verification.
+- `src/utils/eth.ts`: support for anchoring single hashes and merkle roots via contract.
+- `scripts/deploy_anchor.ts` and `scripts/anchor_batch.ts` added for deploy/anchoring flow.
+- `contracts/Anchor.sol` added (event-based anchor contract).
+- `src/issuer.ts` / `src/verifier.ts` updated to use JSON-LD canonicalization and Ed25519 proofs (PoC signing).
+- `scripts/generate_keys.ts` updated to create LD-compatible `keys/issuer-ld.json`.
 
 **Testnets y pruebas de anclaje (Ethereum)**
 

--- a/README.md
+++ b/README.md
@@ -44,3 +44,34 @@ yarn start
 ```
 
 If the vars are not set, the app will keep working and only store local anchors in `data/anchors.json`.
+
+Blockcerts / JSON-LD compatibility (current PoC state)
+
+- This PoC was extended to move toward Blockcerts compatibility:
+	- JSON‑LD canonicalization (URDNA2015) is used before hashing (`jsonld`).
+	- Credentials are signed with Ed25519 (proof in the credential JSON). A Linked‑Data public key artifact is written to `keys/issuer-ld.json`.
+	- Anchors are batched into a Merkle root and can be published on‑chain via an `Anchor` contract event (`contracts/Anchor.sol`).
+	- Utility scripts added: `scripts/deploy_anchor.ts` and `scripts/anchor_batch.ts`.
+
+- New useful commands:
+
+```bash
+# install deps (after editing package.json)
+yarn install
+
+# generate keys (also creates keys/issuer-ld.json)
+yarn gen-keys
+
+# start server
+yarn start
+
+# compile & deploy contract (requires compiled artifact at contracts/Anchor.json)
+node scripts/deploy_anchor.ts
+
+# compute merkle root for pending anchors and anchor to chain
+node scripts/anchor_batch.ts
+```
+
+- Notes & next steps:
+	- The project currently uses `jsonld.canonize(...)` and a PoC signing approach. For full Blockcerts compatibility you should integrate `jsonld-signatures` + `ed25519-signature-2018` (recommended next step).
+	- Keep private keys safe; use only test keys with testnets. See `IMPROVEMENTS.md` for risks and follow‑ups.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,49 @@ yarn start
 
 If the vars are not set, the app will keep working and only store local anchors in `data/anchors.json`.
 
+On‑chain vs off‑chain (por qué TypeScript + Solidity)
+
+- On‑chain (Solidity): el contrato `contracts/Anchor.sol` es el único artefacto que necesita consenso y permanencia en la blockchain. Publica eventos (`AnchorRoot`) con la raíz Merkle o puede recibir un hash en la data de una transacción.
+- Off‑chain (TypeScript): emisión, canonicalización JSON‑LD, firma Ed25519, cálculo de hashes y Merkle proofs, persistencia local, UI/HTTP API y scripts de batching/despliegue. Estas tareas son costosas, no prácticas o imposibles on‑chain por coste y limitaciones técnicas.
+
+Deploy del contrato `Anchor` y anclaje por Merkle (opcional)
+
+1. Preparar entorno (ejemplo con Hardhat):
+
+```bash
+# instalar herramientas (si no las tenés)
+yarn add --dev hardhat @nomiclabs/hardhat-ethers ethers
+npx hardhat init # o crea un proyecto hardhat en esta carpeta
+```
+
+2. Colocar `contracts/Anchor.sol` en el directorio `contracts/` y compilar:
+
+```bash
+npx hardhat compile
+```
+
+3. Desplegar el contrato (usa `scripts/deploy_anchor.ts`): exportar vars y ejecutar:
+
+```bash
+export ETH_RPC=https://sepolia.infura.io/v3/<PROJECT_ID>
+export ETH_PRIVATE_KEY=0xYOUR_TEST_PRIVATE_KEY
+ts-node scripts/deploy_anchor.ts
+```
+
+El script espera encontrar el artefacto compilado en `contracts/Anchor.json` (ABI + bytecode). Tras el despliegue, anota la dirección (`CONTRACT_ADDRESS`) y úsala para `scripts/anchor_batch.ts`.
+
+4. Ejecutar batching para agrupar anchors y publicar la raíz Merkle:
+
+```bash
+export CONTRACT_ADDRESS=0x... # dirección del contrato desplegado
+ts-node scripts/anchor_batch.ts
+```
+
+Precauciones
+- Usá únicamente claves de prueba en testnets. No subir `ETH_PRIVATE_KEY` a repositorios.
+- Publicar en mainnet implica costes de gas.
+
+
 Blockcerts / JSON-LD compatibility (current PoC state)
 
 - This PoC was extended to move toward Blockcerts compatibility:

--- a/contracts/Anchor.sol
+++ b/contracts/Anchor.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract Anchor {
+    event AnchorRoot(bytes32 indexed root, address indexed issuer);
+
+    address public owner;
+
+    constructor() {
+        owner = msg.sender;
+    }
+
+    function anchor(bytes32 root) external returns (bool) {
+        emit AnchorRoot(root, msg.sender);
+        return true;
+    }
+}

--- a/package.json
+++ b/package.json
@@ -9,18 +9,30 @@
     "seed": "ts-node scripts/seed_example.ts"
   },
   "dependencies": {
+    "@digitalbazaar/ed25519-signature-2018": "^4.2.0",
+    "@digitalbazaar/ed25519-verification-key-2018": "^4.0.0",
+    "bs58": "^6.0.0",
+    "ethers": "^6.11.0",
     "express": "^4.18.2",
+    "json-stable-stringify": "^1.0.1",
+    "jsonld": "^9.0.0",
+    "jsonld-signatures": "^11.6.0",
     "nanoid": "^4.0.0",
     "qrcode": "^1.5.1",
-    "tweetnacl": "^1.0.3",
-    "ethers": "^6.11.0"
+    "tweetnacl": "^1.0.3"
+  },
+  "dependenciesMeta": {
+    "json-stable-stringify": {
+      "optional": true
+    }
   },
   "devDependencies": {
-    "ts-node": "^10.9.1",
-    "ts-node-dev": "^2.0.0",
-    "typescript": "^5.1.3",
+    "@types/bs58": "^5.0.0",
     "@types/express": "^4.17.17",
     "@types/node": "^20.2.5",
-    "@types/qrcode": "^1.4.4"
+    "@types/qrcode": "^1.4.4",
+    "ts-node": "^10.9.1",
+    "ts-node-dev": "^2.0.0",
+    "typescript": "^5.1.3"
   }
 }

--- a/scripts/anchor_batch.ts
+++ b/scripts/anchor_batch.ts
@@ -1,0 +1,41 @@
+import fs from 'fs/promises'
+import path from 'path'
+import { merkleRoot } from '../src/utils/merkle'
+import { anchorMerkleRoot } from '../src/utils/eth'
+
+async function main() {
+  const anchorsPath = path.join('data', 'anchors.json')
+  let anchors: any[] = []
+  try { anchors = JSON.parse(await fs.readFile(anchorsPath, 'utf8')) } catch (e) { anchors = [] }
+
+  // select anchors without ethTx/root
+  const pending = anchors.filter(a => !a.ethTx && !a.merkleRoot)
+  if (pending.length === 0) {
+    console.log('No pending anchors')
+    return
+  }
+
+  const leaves = pending.map(p => p.hash)
+  const root = merkleRoot(leaves)
+  console.log('Computed merkle root:', root)
+
+  // anchor via contract
+  const txHash = await anchorMerkleRoot(null, root)
+  console.log('Anchored merkle root tx:', txHash)
+
+  // update anchors with proofs
+  const now = new Date().toISOString()
+  for (let i = 0; i < pending.length; i++) {
+    const p = pending[i]
+    const proof = (await import('../src/utils/merkle')).merkleProof(leaves, i)
+    p.merkleRoot = root
+    p.merkleAnchoredAt = now
+    p.merkleTx = txHash
+    p.merkleIndex = i
+    p.merkleProof = proof
+  }
+
+  await fs.writeFile(anchorsPath, JSON.stringify(anchors, null, 2), 'utf8')
+}
+
+main().catch(e => { console.error(e); process.exit(1) })

--- a/scripts/deploy_anchor.ts
+++ b/scripts/deploy_anchor.ts
@@ -1,0 +1,27 @@
+import { JsonRpcProvider, Wallet, ContractFactory } from 'ethers'
+import fs from 'fs'
+import path from 'path'
+
+async function main() {
+  const rpc = process.env.ETH_RPC
+  const pk = process.env.ETH_PRIVATE_KEY
+  if (!rpc || !pk) throw new Error('Set ETH_RPC and ETH_PRIVATE_KEY')
+
+  const provider = new JsonRpcProvider(rpc)
+  const wallet = new Wallet(pk, provider)
+
+  // read compiled bytecode/abi from hardhat/truffle? For PoC we'll use solc via hardcoded ABI+bytecode if available.
+  // For simplicity assume user compiled and placed artifact at contracts/Anchor.json
+  const artPath = path.join(process.cwd(), 'contracts', 'Anchor.json')
+  if (!fs.existsSync(artPath)) throw new Error('contracts/Anchor.json artifact not found. Compile contract first.')
+
+  const artifact = JSON.parse(fs.readFileSync(artPath, 'utf8'))
+  const factory = new ContractFactory(artifact.abi, artifact.bytecode, wallet)
+  const contract = await factory.deploy()
+  await contract.deployed()
+  console.log('Deployed Anchor at', contract.address)
+
+  // Optionally write address to .env or print instructions
+}
+
+main().catch((e) => { console.error(e); process.exit(1) })

--- a/scripts/generate_keys.ts
+++ b/scripts/generate_keys.ts
@@ -1,10 +1,28 @@
 import { generateKeypair, saveKey } from '../src/utils/crypto'
+import bs58 from 'bs58'
+import fs from 'fs/promises'
 
 async function main() {
   const kp = await generateKeypair()
   await saveKey('keys/issuer.pub', kp.publicKey)
   await saveKey('keys/issuer.key', kp.secretKey)
-  console.log('Keys generated in keys/ (issuer.pub, issuer.key)')
+
+  // Also generate a Linked Data compatible public key (base58) for LD signatures
+  // tweetnacl publicKey is base64; convert to base58
+  const pubBuf = Buffer.from(kp.publicKey, 'base64')
+  const pub58 = bs58.encode(pubBuf)
+
+  const ld = {
+    id: 'keys/issuer-ld',
+    type: 'Ed25519VerificationKey2018',
+    controller: 'urn:example:issuer',
+    publicKeyBase58: pub58
+  }
+
+  await fs.mkdir('keys', { recursive: true })
+  await fs.writeFile('keys/issuer-ld.json', JSON.stringify(ld, null, 2), 'utf8')
+
+  console.log('Keys generated in keys/ (issuer.pub, issuer.key, issuer-ld.json)')
 }
 
 main().catch(e => { console.error(e); process.exit(1) })

--- a/src/issuer.ts
+++ b/src/issuer.ts
@@ -2,6 +2,7 @@ import { nanoid } from 'nanoid'
 import fs from 'fs/promises'
 import path from 'path'
 import { sha256, signMessage, loadKey } from './utils/crypto'
+import * as jsonld from 'jsonld'
 import { anchorToEthereum } from './utils/eth'
 
 type Subject = { id?: string; [k: string]: any }
@@ -19,14 +20,16 @@ export async function issueCredential(subject: Subject, issuerName = 'Demo Issue
     credentialSubject: subject
   }
 
-  // compute hash of credential without proof
-  const hash = sha256(JSON.stringify(credentialWithoutProof))
+  // canonicalize (JSON-LD URDNA2015) and compute hash of credential without proof
+  const canonical = await jsonld.canonize(credentialWithoutProof, { algorithm: 'URDNA2015', format: 'application/n-quads' })
+  const hash = sha256(canonical)
 
   // load issuer secret key
   const secret = await loadKey('keys/issuer.key')
   if (!secret) throw new Error('Issuer key not found. Run gen-keys.')
 
-  const signature = signMessage(secret, Buffer.from(hash, 'hex'))
+  // sign the canonical representation (Ed25519 detached)
+  const signature = signMessage(secret, Buffer.from(canonical, 'utf8'))
 
   const proof = {
     type: 'Ed25519Signature2018',

--- a/src/types/jsonld.d.ts
+++ b/src/types/jsonld.d.ts
@@ -1,0 +1,8 @@
+declare module 'jsonld' {
+  export function canonize(input: any, options?: any): Promise<string>
+  export function expand(input: any, options?: any): Promise<any>
+  export function compact(input: any, context: any, options?: any): Promise<any>
+  export function toRDF(input: any, options?: any): Promise<any>
+}
+
+export {}

--- a/src/utils/eth.ts
+++ b/src/utils/eth.ts
@@ -1,14 +1,14 @@
-import { ethers } from 'ethers'
+import { JsonRpcProvider, Wallet, Contract } from 'ethers'
 
-// Anchor a hex hash (without 0x) on Ethereum by sending a zero-value tx
+// Anchor a single hex hash (without 0x) on Ethereum by sending a zero-value tx
 // with the hash in the data field. Uses env vars: ETH_RPC, ETH_PRIVATE_KEY.
 export async function anchorToEthereum(hashHex: string) {
   const rpc = process.env.ETH_RPC
   const pk = process.env.ETH_PRIVATE_KEY
   if (!rpc || !pk) throw new Error('ETH_RPC or ETH_PRIVATE_KEY not configured')
 
-  const provider = new ethers.providers.JsonRpcProvider(rpc)
-  const wallet = new ethers.Wallet(pk, provider)
+  const provider = new JsonRpcProvider(rpc)
+  const wallet = new Wallet(pk, provider)
 
   const tx = await wallet.sendTransaction({
     to: wallet.address,
@@ -16,7 +16,29 @@ export async function anchorToEthereum(hashHex: string) {
     data: '0x' + hashHex
   })
 
-  // wait for 1 confirmation
+  await tx.wait(1)
+  return tx.hash
+}
+
+// Anchor a merkle root using a deployed Anchor contract that emits an event.
+// Requires CONTRACT_ADDRESS env var or pass the address explicitly.
+export async function anchorMerkleRoot(contractAddress: string | null, rootHex: string) {
+  const rpc = process.env.ETH_RPC
+  const pk = process.env.ETH_PRIVATE_KEY
+  const addr = contractAddress || process.env.CONTRACT_ADDRESS
+  if (!rpc || !pk) throw new Error('ETH_RPC or ETH_PRIVATE_KEY not configured')
+  if (!addr) throw new Error('CONTRACT_ADDRESS not configured')
+
+  const provider = new JsonRpcProvider(rpc)
+  const wallet = new Wallet(pk, provider)
+
+  const abi = [
+    'function anchor(bytes32 root) external returns (bool)',
+    'event AnchorRoot(bytes32 indexed root, address indexed issuer)'
+  ]
+
+  const contract = new Contract(addr, abi, wallet)
+  const tx = await contract.anchor('0x' + rootHex)
   await tx.wait(1)
   return tx.hash
 }

--- a/src/utils/merkle.ts
+++ b/src/utils/merkle.ts
@@ -1,0 +1,63 @@
+import { sha256 } from './crypto'
+
+function normHex(hex: string) {
+  return (hex.startsWith('0x') ? hex.slice(2) : hex).toLowerCase()
+}
+
+export function merkleRoot(hexLeaves: string[]): string {
+  if (!hexLeaves || hexLeaves.length === 0) return ''
+  let nodes = hexLeaves.map(h => normHex(h))
+
+  while (nodes.length > 1) {
+    const next: string[] = []
+    for (let i = 0; i < nodes.length; i += 2) {
+      const left = nodes[i]
+      const right = i + 1 < nodes.length ? nodes[i + 1] : nodes[i]
+      const combined = Buffer.from(left + right, 'hex')
+      const h = sha256(combined)
+      next.push(h)
+    }
+    nodes = next
+  }
+
+  return nodes[0]
+}
+
+export function merkleProof(hexLeaves: string[], index: number) {
+  const leaves = hexLeaves.map(h => normHex(h))
+  const proof: Array<{ sibling: string; position: 'left' | 'right' }> = []
+  let idx = index
+  let layer = leaves.slice()
+
+  while (layer.length > 1) {
+    const next: string[] = []
+    for (let i = 0; i < layer.length; i += 2) {
+      const left = layer[i]
+      const right = i + 1 < layer.length ? layer[i + 1] : layer[i]
+      next.push(sha256(Buffer.from(left + right, 'hex')))
+      if (i === idx || i + 1 === idx) {
+        const isLeft = idx % 2 === 0
+        const sibling = isLeft ? right : left
+        proof.push({ sibling, position: isLeft ? 'right' : 'left' })
+        idx = Math.floor(i / 2)
+      }
+    }
+    layer = next
+  }
+
+  return proof
+}
+
+export function verifyProof(leafHex: string, proof: Array<{ sibling: string; position: 'left' | 'right' }>, rootHex: string) {
+  let hash = normHex(leafHex)
+  for (const p of proof) {
+    if (p.position === 'left') {
+      hash = sha256(Buffer.from(p.sibling + hash, 'hex'))
+    } else {
+      hash = sha256(Buffer.from(hash + p.sibling, 'hex'))
+    }
+  }
+  return normHex(rootHex) === hash
+}
+
+export default merkleRoot

--- a/src/verifier.ts
+++ b/src/verifier.ts
@@ -1,15 +1,18 @@
 import fs from 'fs/promises'
 import path from 'path'
 import { sha256, verifyMessage, loadKey } from './utils/crypto'
+import * as jsonld from 'jsonld'
+import { verifyProof } from './utils/merkle'
 
 export async function verifyCredential(credential: any) {
   // extract proof
   const proof = credential.proof
   if (!proof) return { valid: false, reasons: ['no proof present'] }
 
-  // compute hash of credential without proof
+  // canonicalize credential without proof (JSON-LD URDNA2015) and compute hash
   const { proof: _p, ...withoutProof } = credential
-  const hash = sha256(JSON.stringify(withoutProof))
+  const canonical = await jsonld.canonize(withoutProof, { algorithm: 'URDNA2015', format: 'application/n-quads' })
+  const hash = sha256(canonical)
 
   // load anchors
   const anchorsPath = path.join('data', 'anchors.json')
@@ -21,8 +24,15 @@ export async function verifyCredential(credential: any) {
   const pub = await loadKey('keys/issuer.pub')
   if (!pub) return { valid: false, reasons: ['issuer public key not found'] }
 
-  const ok = verifyMessage(pub, Buffer.from(hash, 'hex'), proof.signatureValue)
+  // verify signature against canonical bytes
+  const ok = verifyMessage(pub, Buffer.from(canonical, 'utf8'), proof.signatureValue)
   if (!ok) return { valid: false, reasons: ['signature invalid'] }
+
+  // if merkle data present, verify inclusion
+  if (anchored.merkleRoot && anchored.merkleProof) {
+    const okProof = verifyProof(anchored.hash, anchored.merkleProof, anchored.merkleRoot)
+    if (!okProof) return { valid: false, reasons: ['merkle proof invalid'] }
+  }
 
   return { valid: true, reasons: [] }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "outDir": "dist",
     "strict": true,
     "esModuleInterop": true,
+    "typeRoots": ["./src/types", "./node_modules/@types"],
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,6 +14,59 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
+"@digitalbazaar/ed25519-signature-2018@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@digitalbazaar/ed25519-signature-2018/-/ed25519-signature-2018-4.2.0.tgz#70eb5bc05d40e8917e58799640e345508b718073"
+  integrity sha512-JZn8oazkjKMU4+yg+7ogk3yXWyUVJ4XyWi7CQrTrJEHuBd+YbztaeZQBMFX3Ic1iDag3yoH+CgotrbCrtf3HJQ==
+  dependencies:
+    "@digitalbazaar/ed25519-verification-key-2018" "^4.0.0"
+    "@digitalbazaar/ed25519-verification-key-2020" "^4.2.0"
+    "@digitalbazaar/jws-linked-data-signature" "^3.0.0"
+    base58-universal "^2.0.0"
+    ed25519-signature-2018-context "^1.1.0"
+    ed25519-signature-2020-context "^1.1.0"
+    jsonld "^9.0.0"
+
+"@digitalbazaar/ed25519-verification-key-2018@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@digitalbazaar/ed25519-verification-key-2018/-/ed25519-verification-key-2018-4.0.0.tgz#0873fbd2c4d44ff06fbadf057bb4c0b93b1c0cd8"
+  integrity sha512-65O08XDDJYZVeQJ86fd7ClZLzMwQsJ0zQpLhvzjE9LRGrD0BPwWFrC/vNW3XTYzzvNwbP7ipFomF95JgGLzabQ==
+  dependencies:
+    "@noble/ed25519" "^1.6.0"
+    base58-universal "^2.0.0"
+    crypto-ld "^7.0.0"
+
+"@digitalbazaar/ed25519-verification-key-2020@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@digitalbazaar/ed25519-verification-key-2020/-/ed25519-verification-key-2020-4.2.0.tgz#4a394c7c137ead8edf415c83bbd3c40b73c95b49"
+  integrity sha512-urEVTYkt+uYD8GjdoS6gkm2sKBich1hqx42b6vvUOmNgF0agZ95JlUjiJXEx+VOwu7WSjJSnEBph2Qatkrk1CA==
+  dependencies:
+    "@noble/ed25519" "^1.6.0"
+    base58-universal "^2.0.0"
+    base64url-universal "^2.0.0"
+    crypto-ld "^7.0.0"
+
+"@digitalbazaar/http-client@^4.2.0":
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/@digitalbazaar/http-client/-/http-client-4.3.0.tgz#c76e738c8c8402d3bd11891932219a5163efd8c3"
+  integrity sha512-6lMpxpt9BOmqHKGs9Xm6DP4LlZTBFer/ZjHvP3FcW3IaUWYIWC7dw5RFZnvw4fP57kAVcm1dp3IF+Y50qhBvAw==
+  dependencies:
+    ky "^1.14.2"
+    undici "^6.23.0"
+
+"@digitalbazaar/jws-linked-data-signature@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@digitalbazaar/jws-linked-data-signature/-/jws-linked-data-signature-3.0.0.tgz#bd352319c8c67b130c50a0d99d0322e80011104a"
+  integrity sha512-OE0LIwXeF3P8GZKphXb7jLqgUFMnDtbKZQCOqfMysUUIg2f4CLZIEbYbzZEP3cAE/MLoubIxl81QeGRyZ71ICg==
+  dependencies:
+    base64url-universal "^2.0.0"
+    jsonld-signatures "^11.0.0"
+
+"@digitalbazaar/security-context@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@digitalbazaar/security-context/-/security-context-1.0.1.tgz#badc4b8da03411a32d4e7321ce7c4b355776b410"
+  integrity sha512-0WZa6tPiTZZF8leBtQgYAfXQePFQp2z5ivpCEN/iZguYYZ0TB9qRmWtan5XH6mNFuusHtMcyIzAcReyE6rZPhA==
+
 "@jridgewell/resolve-uri@^3.0.3":
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz#7a0ee601f60f99a20c7c7c5ff0c80388c1189bd6"
@@ -38,6 +91,11 @@
   integrity sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==
   dependencies:
     "@noble/hashes" "1.3.2"
+
+"@noble/ed25519@^1.6.0":
+  version "1.7.5"
+  resolved "https://registry.yarnpkg.com/@noble/ed25519/-/ed25519-1.7.5.tgz#94df8bdb9fec9c4644a56007eecb57b0e9fbd0d7"
+  integrity sha512-xuS0nwRMQBvSxDa7UxMb61xTiH3MxTgUfhyPUALVIe0FlOAz4sjELwyDRyUvqeEYfRSG9qNjFIycqLZppg4RSA==
 
 "@noble/hashes@1.3.2":
   version "1.3.2"
@@ -71,6 +129,13 @@
   dependencies:
     "@types/connect" "*"
     "@types/node" "*"
+
+"@types/bs58@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@types/bs58/-/bs58-5.0.0.tgz#a5f849d47263b2dfb09846306256c56610d40cb0"
+  integrity sha512-cAw/jKBzo98m6Xz1X5ETqymWfIMbXbu6nK15W4LQYjeHJkVqSmM5PO8Bd9KVHQJ/F4rHcSso9LcjtgCW6TGu2w==
+  dependencies:
+    bs58 "*"
 
 "@types/connect@*":
   version "3.4.38"
@@ -241,6 +306,28 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+base-x@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/base-x/-/base-x-5.0.1.tgz#16bf35254be1df8aca15e36b7c1dda74b2aa6b03"
+  integrity sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==
+
+base58-universal@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/base58-universal/-/base58-universal-2.0.0.tgz#243c8256591afa7d5210f87ad1655e05081f4be4"
+  integrity sha512-BgkgF8zVLOAygszG4W8NkLm7iXrw80VYAOcedrzANrIhS14+4W6zVqjyGTFUBM/FpqkHUt8aAYd4DbBBfn3zKg==
+
+base64url-universal@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/base64url-universal/-/base64url-universal-2.0.0.tgz#6023785c0e349a90de1cf396e8a4519750a4e67b"
+  integrity sha512-6Hpg7EBf3t148C3+fMzjf+CHnADVDafWzlJUXAqqqbm4MKNXbsoPdOkWeRTjNlkYG7TpyjIpRO1Gk0SnsFD1rw==
+  dependencies:
+    base64url "^3.0.1"
+
+base64url@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/base64url/-/base64url-3.0.1.tgz#6399d572e2bc3f90a9a8b22d5dbb0a32d33f788d"
+  integrity sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==
+
 binary-extensions@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.3.0.tgz#f6e14a97858d327252200242d4ccfe522c445522"
@@ -279,6 +366,13 @@ braces@~3.0.2:
   dependencies:
     fill-range "^7.1.1"
 
+bs58@*, bs58@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/bs58/-/bs58-6.0.0.tgz#a2cda0130558535dd281a2f8697df79caaf425d8"
+  integrity sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==
+  dependencies:
+    base-x "^5.0.0"
+
 buffer-from@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
@@ -289,7 +383,7 @@ bytes@~3.1.2:
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
   integrity sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==
 
-call-bind-apply-helpers@^1.0.1, call-bind-apply-helpers@^1.0.2:
+call-bind-apply-helpers@^1.0.0, call-bind-apply-helpers@^1.0.1, call-bind-apply-helpers@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz#4b5428c222be985d79c3d82657479dbe0b59b2d6"
   integrity sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==
@@ -297,7 +391,17 @@ call-bind-apply-helpers@^1.0.1, call-bind-apply-helpers@^1.0.2:
     es-errors "^1.3.0"
     function-bind "^1.1.2"
 
-call-bound@^1.0.2:
+call-bind@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.8.tgz#0736a9660f537e3388826f440d5ec45f744eaa4c"
+  integrity sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==
+  dependencies:
+    call-bind-apply-helpers "^1.0.0"
+    es-define-property "^1.0.0"
+    get-intrinsic "^1.2.4"
+    set-function-length "^1.2.2"
+
+call-bound@^1.0.2, call-bound@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/call-bound/-/call-bound-1.0.4.tgz#238de935d2a2a692928c538c7ccfa91067fd062a"
   integrity sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==
@@ -309,6 +413,11 @@ camelcase@^5.0.0:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
+
+canonicalize@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/canonicalize/-/canonicalize-2.1.0.tgz#92a20ecfb94e96591badf4977dc2fb1bfbc31dc5"
+  integrity sha512-F705O3xrsUtgt98j7leetNhTWPe+5S72rlL5O4jA1pKqBVQ/dT1O1D6PFxmSXvc0SUOinWS57DKx0I3CHrXJHQ==
 
 chokidar@^3.5.1:
   version "3.6.0"
@@ -378,6 +487,11 @@ create-require@^1.1.0:
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
+crypto-ld@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/crypto-ld/-/crypto-ld-7.0.0.tgz#ad593cce31da84e60bd14fd2b25221f97e8a3b74"
+  integrity sha512-RrXy6aB0TOhSiqsgavTQt1G8mKomKIaNLb2JZxj7A/Vi0EwmXguuBQoeiAvePfK6bDR3uQbqYnaLLs4irTWwgw==
+
 debug@2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -389,6 +503,15 @@ decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==
+
+define-data-property@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/define-data-property/-/define-data-property-1.1.4.tgz#894dc141bb7d3060ae4366f6a0107e68fbe48c5e"
+  integrity sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==
+  dependencies:
+    es-define-property "^1.0.0"
+    es-errors "^1.3.0"
+    gopd "^1.0.1"
 
 depd@2.0.0, depd@~2.0.0:
   version "2.0.0"
@@ -426,6 +549,16 @@ dynamic-dedupe@^0.3.0:
   dependencies:
     xtend "^4.0.0"
 
+ed25519-signature-2018-context@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/ed25519-signature-2018-context/-/ed25519-signature-2018-context-1.1.0.tgz#68002ea7497c32e8170667cfd67468dedf7d220e"
+  integrity sha512-ppDWYMNwwp9bploq0fS4l048vHIq41nWsAbPq6H4mNVx9G/GxW3fwg4Ln0mqctP13MoEpREK7Biz8TbVVdYXqA==
+
+ed25519-signature-2020-context@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/ed25519-signature-2020-context/-/ed25519-signature-2020-context-1.1.0.tgz#b2f724f07db154ddf0fd6605410d88736e56fd07"
+  integrity sha512-dBGSmoUIK6h2vadDctrDnhhTO01PR2hJk0mRNEfrRDPCjaIwrfy4J+eziEQ9Q1m8By4f/CSRgKM1h53ydKfdNg==
+
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
@@ -441,7 +574,7 @@ encodeurl@~2.0.0:
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-2.0.0.tgz#7b8ea898077d7e409d3ac45474ea38eaf0857a58"
   integrity sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==
 
-es-define-property@^1.0.1:
+es-define-property@^1.0.0, es-define-property@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/es-define-property/-/es-define-property-1.0.1.tgz#983eb2f9a6724e9303f61addf011c72e09e0b0fa"
   integrity sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==
@@ -576,7 +709,7 @@ get-caller-file@^2.0.1:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
-get-intrinsic@^1.2.5, get-intrinsic@^1.3.0:
+get-intrinsic@^1.2.4, get-intrinsic@^1.2.5, get-intrinsic@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz#743f0e3b6964a93a5491ed1bffaae054d7f98d01"
   integrity sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==
@@ -619,10 +752,17 @@ glob@^7.1.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-gopd@^1.2.0:
+gopd@^1.0.1, gopd@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.2.0.tgz#89f56b8217bdbc8802bd299df6d7f1081d7e51a1"
   integrity sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==
+
+has-property-descriptors@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz#963ed7d071dc7bf5f084c5bfbe0d1b6222586854"
+  integrity sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==
+  dependencies:
+    es-define-property "^1.0.0"
 
 has-symbols@^1.1.0:
   version "1.1.0"
@@ -708,12 +848,65 @@ is-number@^7.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
+isarray@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.5.tgz#8af1e4c1221244cc62459faf38940d4e644a5723"
+  integrity sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==
+
+json-stable-stringify@^1.0.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz#8903cfac42ea1a0f97f35d63a4ce0518f0cc6a70"
+  integrity sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==
+  dependencies:
+    call-bind "^1.0.8"
+    call-bound "^1.0.4"
+    isarray "^2.0.5"
+    jsonify "^0.0.1"
+    object-keys "^1.1.1"
+
+jsonify@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.1.tgz#2aa3111dae3d34a0f151c63f3a45d995d9420978"
+  integrity sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==
+
+jsonld-signatures@^11.0.0, jsonld-signatures@^11.6.0:
+  version "11.6.0"
+  resolved "https://registry.yarnpkg.com/jsonld-signatures/-/jsonld-signatures-11.6.0.tgz#052432d765fe51942749458062bc7a336920681f"
+  integrity sha512-hzYNZXnfy4cUFf9aiFBtduUz+cknbfBLWtTKvoqVyP2ECPwqfsfkHWFlhccWfAKV/LJkPLyKZRwC1B4T5LO4ZQ==
+  dependencies:
+    "@digitalbazaar/security-context" "^1.0.0"
+    jsonld "^9.0.0"
+    rdf-canonize "^5.0.0"
+    serialize-error "^8.1.0"
+
+jsonld@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/jsonld/-/jsonld-9.0.0.tgz#2b7266a377e1e5e6f49d69a60cef957c2945c3b4"
+  integrity sha512-pjMIdkXfC1T2wrX9B9i2uXhGdyCmgec3qgMht+TDj+S0qX3bjWMQUfL7NeqEhuRTi8G5ESzmL9uGlST7nzSEWg==
+  dependencies:
+    "@digitalbazaar/http-client" "^4.2.0"
+    canonicalize "^2.1.0"
+    lru-cache "^6.0.0"
+    rdf-canonize "^5.0.0"
+
+ky@^1.14.2:
+  version "1.14.3"
+  resolved "https://registry.yarnpkg.com/ky/-/ky-1.14.3.tgz#d7fcc6ac93d1588accee72cc44dcc6cf84c0bdaa"
+  integrity sha512-9zy9lkjac+TR1c2tG+mkNSVlyOpInnWdSMiue4F+kq8TwJSgv6o8jhLRg8Ho6SnZ9wOYUq/yozts9qQCfk7bIw==
+
 locate-path@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-5.0.0.tgz#1afba396afd676a6d42504d0a67a3a7eb9f62aa0"
   integrity sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==
   dependencies:
     p-locate "^4.1.0"
+
+lru-cache@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
+  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
+  dependencies:
+    yallist "^4.0.0"
 
 make-error@^1.1.1:
   version "1.3.6"
@@ -803,6 +996,11 @@ object-inspect@^1.13.3:
   version "1.13.4"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.13.4.tgz#8375265e21bc20d0fa582c22e1b13485d6e00213"
   integrity sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==
+
+object-keys@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
+  integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
 
 on-finished@~2.4.1:
   version "2.4.1"
@@ -911,6 +1109,13 @@ raw-body@~2.5.3:
     iconv-lite "~0.4.24"
     unpipe "~1.0.0"
 
+rdf-canonize@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/rdf-canonize/-/rdf-canonize-5.0.0.tgz#0bbad390c4beebaadf820e3888d495ac0b8cfb05"
+  integrity sha512-g8OUrgMXAR9ys/ZuJVfBr05sPPoMA7nHIVs8VEvg9QwM5W4GR2qSFEEHjsyHF1eWlBaf8Ev40WNjQFQ+nJTO3w==
+  dependencies:
+    setimmediate "^1.0.5"
+
 readdirp@~3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.6.0.tgz#74a370bd857116e245b29cc97340cd431a02a6c7"
@@ -973,6 +1178,13 @@ send@~0.19.0, send@~0.19.1:
     range-parser "~1.2.1"
     statuses "~2.0.2"
 
+serialize-error@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/serialize-error/-/serialize-error-8.1.0.tgz#3a069970c712f78634942ddd50fbbc0eaebe2f67"
+  integrity sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ==
+  dependencies:
+    type-fest "^0.20.2"
+
 serve-static@~1.16.2:
   version "1.16.3"
   resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.16.3.tgz#a97b74d955778583f3862a4f0b841eb4d5d78cf9"
@@ -987,6 +1199,23 @@ set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==
+
+set-function-length@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/set-function-length/-/set-function-length-1.2.2.tgz#aac72314198eaed975cf77b2c3b6b880695e5449"
+  integrity sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==
+  dependencies:
+    define-data-property "^1.1.4"
+    es-errors "^1.3.0"
+    function-bind "^1.1.2"
+    get-intrinsic "^1.2.4"
+    gopd "^1.0.1"
+    has-property-descriptors "^1.0.2"
+
+setimmediate@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
+  integrity sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==
 
 setprototypeof@1.2.0, setprototypeof@~1.2.0:
   version "1.2.0"
@@ -1154,6 +1383,11 @@ tweetnacl@^1.0.3:
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-1.0.3.tgz#ac0af71680458d8a6378d0d0d050ab1407d35596"
   integrity sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==
 
+type-fest@^0.20.2:
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
+  integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
+
 type-is@~1.6.18:
   version "1.6.18"
   resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.18.tgz#4e552cd05df09467dcbc4ef739de89f2cf37c131"
@@ -1181,6 +1415,11 @@ undici-types@~7.18.0:
   version "7.18.2"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.18.2.tgz#29357a89e7b7ca4aef3bf0fd3fd0cd73884229e9"
   integrity sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==
+
+undici@^6.23.0:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-6.24.1.tgz#9df1425cede20b836d95634347946f79578b7e71"
+  integrity sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==
 
 unpipe@~1.0.0:
   version "1.0.0"
@@ -1235,6 +1474,11 @@ y18n@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.3.tgz#b5f259c82cd6e336921efd7bfd8bf560de9eeedf"
   integrity sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==
+
+yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yargs-parser@^18.1.2:
   version "18.1.3"


### PR DESCRIPTION
# Diferencias: rama `blockcerts` vs `useEters`

Resumen breve
- La rama `blockcerts` nace de `useEters` y extiende el PoC añadiendo soporte para anclaje en cadena mediante un contrato inteligente y anchoring por merkle roots. Mantiene compatibilidad con el anclaje local si no se configuran las variables de entorno.

Cambios principales
- Nuevo contrato: `contracts/Anchor.sol` — contrato simple que emite evento `AnchorRoot(bytes32 root, address issuer)`.
- Nuevos scripts:
  - `scripts/deploy_anchor.ts` — despliega el contrato `Anchor` usando `ethers`.
  - `scripts/anchor_batch.ts` — calcula un Merkle root a partir de `data/anchors.json`, lo ancla usando el contrato y escribe pruebas Merkle (proofs) y metadatos en los anchors.
- Nuevos/Modificados utilitarios:
  - `src/utils/merkle.ts` — NUEVO: funciones `merkleRoot`, `merkleProof`, `verifyProof` para generar/verificar árboles Merkle.
  - `src/utils/eth.ts` — MOD: además de `anchorToEthereum(hash)`, añade `anchorMerkleRoot(contractAddress, rootHex)` que llama al contrato `Anchor.anchor(bytes32)` y espera confirmación.
  - `src/types/jsonld.d.ts` — NUEVO: tipos para `jsonld` (compatibilidad TS).
- Lógica de emisión/verificación:
  - `src/issuer.ts` — ahora usa `jsonld.canonize(..., { algorithm: 'URDNA2015' })` para generar representación canónica del credential antes de hashear y firmar (mejora determinismo). Sigue intentando anclar individualmente y registra `ethTx` si corresponde.
  - `src/verifier.ts` — ahora verifica hash canónico y, si el anchor contiene `merkleRoot` y `merkleProof`, valida la inclusión con `verifyProof`.
- Config/otros:
  - `tsconfig.json` — modificado para incluir tipos o paths (ver commits).
  - `package.json` / `yarn.lock` — actualizados (dependencias para `ethers`, `jsonld`, etc.).
  - `scripts/generate_keys.ts` — menor modificación (compatibilidad con nuevos tipos).
  - `README.md` / `IMPROVEMENTS.md` — documentan el nuevo flujo de anclaje y pruebas en testnet/contract.

Fragmentos relevantes

- Contrato `contracts/Anchor.sol` (nuevo):

```solidity
pragma solidity ^0.8.0;

contract Anchor {
    event AnchorRoot(bytes32 indexed root, address indexed issuer);

    address public owner;

    constructor() { owner = msg.sender; }

    function anchor(bytes32 root) external returns (bool) {
        emit AnchorRoot(root, msg.sender);
        return true;
    }
}
```

- Uso de JSON-LD canonicalization en `src/issuer.ts`:

```ts
const canonical = await jsonld.canonize(credentialWithoutProof, { algorithm: 'URDNA2015', format: 'application/n-quads' })
const hash = sha256(canonical)
```

- Función Merkle (resumen) en `src/utils/merkle.ts`:

```ts
export function merkleRoot(hexLeaves: string[]): string { /* combina pares y hashea hasta la raíz */ }
export function merkleProof(hexLeaves: string[], index: number) { /* genera proof */ }
export function verifyProof(leafHex: string, proof, rootHex: string) { /* verifica */ }
```

- Anclaje de Merkle via contrato en `src/utils/eth.ts`:

```ts
export async function anchorMerkleRoot(contractAddress: string | null, rootHex: string) {
  // usa CONTRACT_ADDRESS o parametro, llama contract.anchor('0x'+rootHex)
}
```

Notas:
- Funcionalidad nueva: anclaje escalable por Merkle + contrato on-chain, permite agrupar múltiples anchors en una sola transacción y publicar un evento verificable.
- Backward compatible: si no hay `ETH_RPC` / `ETH_PRIVATE_KEY` / `CONTRACT_ADDRESS`, la app sigue guardando anchors localmente.
- Recomendaciones antes de mergear:
  - Añadir `.env.sample` con `ETH_RPC`, `ETH_PRIVATE_KEY`, `CONTRACT_ADDRESS`.
  - Documentar pasos de compilación del contrato (`solc`/Hardhat) y ubicación esperada de artefactos (`contracts/Anchor.json`) para `scripts/deploy_anchor.ts`.
  - Tests: mockear `anchorToEthereum` y `anchorMerkleRoot` en pruebas unitarias; añadir tests para `merkleRoot`/`verifyProof`.
  - Seguridad: advertir sobre no usar claves reales en `ETH_PRIVATE_KEY` y los costes de gas en testnets/mainnet.

Archivos añadidos/modificados (lista)
- A  contracts/Anchor.sol
- A  scripts/anchor_batch.ts
- A  scripts/deploy_anchor.ts
- M  scripts/generate_keys.ts
- A  src/types/jsonld.d.ts
- A  src/utils/merkle.ts
- M  src/utils/eth.ts
- M  src/issuer.ts
- M  src/verifier.ts
- M  README.md
- M  IMPROVEMENTS.md
- M  package.json
- M  tsconfig.json
- M  yarn.lock


